### PR TITLE
Allow `clippy::wildcard_imports`, and `clippy::unreadable_literal` in generated code

### DIFF
--- a/src/mods/sets.rs
+++ b/src/mods/sets.rs
@@ -177,7 +177,9 @@ fn create_set_module_file(module_dir: &Path, module_index: usize) -> io::Result<
 
     writeln!(
         set_module,
-        "use super::*;
+        "#[allow(clippy::wildcard_imports)]
+use super::*;
+#[allow(clippy::unreadable_literal)]
 pub(crate) fn generate({}: &mut HashMap<&'static str, Resource>) {{",
         DEFAULT_VARIABLE_NAME
     )?;


### PR DESCRIPTION
Clippy warns about both in the generated files. This PR silences the warnings.

---

Aside: Currently, the build script of this crate runs when having the crate as a dependency. This seems unnecessary - it should only run in tests.